### PR TITLE
Mockup api 생성

### DIFF
--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -2,14 +2,20 @@ package com.codesquad.esfj.todolist.task;
 
 public class Task {
 
+    private Long id;
     private String title;
     private String content;
     private String writer;
 
-    public Task(String title, String content, String writer) {
+    public Task(Long id, String title, String content, String writer) {
+        this.id = id;
         this.title = title;
         this.content = content;
         this.writer = writer;
+    }
+
+    public Long getId() {
+        return id;
     }
 
     public String getTitle() {

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -41,8 +41,8 @@ public class Task {
         return previousId;
     }
 
-    public void moveAfter(Long previousId) {
-        this.previousId = previousId;
+    public void moveAfter(Long targetId) {
+       previousId = targetId;
     }
 
     public boolean isDeleted() {

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -29,4 +29,14 @@ public class Task {
     public String getWriter() {
         return writer;
     }
+
+    @Override
+    public String toString() {
+        return "Task{" +
+                "id=" + id +
+                ", title='" + title + '\'' +
+                ", content='" + content + '\'' +
+                ", writer='" + writer + '\'' +
+                '}';
+    }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -61,10 +61,6 @@ public class Task {
         return this;
     }
 
-    public boolean isTop() {
-        return (id.equals(TOP_PREVIOUS_ID));
-    }
-
     @Override
     public String toString() {
         return "Task{" +

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -1,0 +1,26 @@
+package com.codesquad.esfj.todolist.task;
+
+public class Task {
+
+    private String title;
+    private String content;
+    private String writer;
+
+    public Task(String title, String content, String writer) {
+        this.title = title;
+        this.content = content;
+        this.writer = writer;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getContent() {
+        return content;
+    }
+
+    public String getWriter() {
+        return writer;
+    }
+}

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -1,12 +1,14 @@
 package com.codesquad.esfj.todolist.task;
 
 public class Task {
+    public static final long TOP_PREVIOUS_ID = -1L;
 
     private Long id;
     private String title;
     private String content;
     private String writer;
     private boolean deleted;
+    private Long previousId = TOP_PREVIOUS_ID;
 
     public Task(Long id, String title, String content, String writer) {
         this.id = id;
@@ -35,6 +37,14 @@ public class Task {
         return writer;
     }
 
+    public Long getPreviousId() {
+        return previousId;
+    }
+
+    public void moveAfter(Long previousId) {
+        this.previousId = previousId;
+    }
+
     public boolean isDeleted() {
         return deleted;
     }
@@ -49,6 +59,10 @@ public class Task {
     public Task delete() {
         deleted = true;
         return this;
+    }
+
+    public boolean isTop() {
+        return (id.equals(TOP_PREVIOUS_ID));
     }
 
     @Override

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -19,6 +19,10 @@ public class Task {
         return id;
     }
 
+    public void setId(Long id) {
+        this.id = id;
+    }
+
     public String getTitle() {
         return title;
     }
@@ -31,8 +35,20 @@ public class Task {
         return writer;
     }
 
-    public void delete() {
+    public boolean isDeleted() {
+        return deleted;
+    }
+
+    public Task update(Task updatedTask) {
+        this.title = updatedTask.title;
+        this.content = updatedTask.content;
+        this.writer = updatedTask.writer;
+        return this;
+    }
+
+    public Task delete() {
         deleted = true;
+        return this;
     }
 
     @Override

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/Task.java
@@ -6,6 +6,7 @@ public class Task {
     private String title;
     private String content;
     private String writer;
+    private boolean deleted;
 
     public Task(Long id, String title, String content, String writer) {
         this.id = id;
@@ -28,6 +29,10 @@ public class Task {
 
     public String getWriter() {
         return writer;
+    }
+
+    public void delete() {
+        deleted = true;
     }
 
     @Override

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -1,6 +1,7 @@
 package com.codesquad.esfj.todolist.task;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.*;
@@ -10,8 +11,13 @@ public class TaskController {
 
     @GetMapping("/tasks")
     public List<Task> readAll() {
-        return Arrays.asList(new Task("title1", "content1", "writer1"),
-                new Task("title2", "content2", "writer2"),
-                new Task("title3", "content3", "writer3"));
+        return Arrays.asList(new Task(1L, "title1", "content1", "writer1"),
+                new Task(2L, "title2", "content2", "writer2"),
+                new Task(3L, "title3", "content3", "writer3"));
+    }
+
+    @GetMapping("/tasks/{id}")
+    public Task readOne(@PathVariable Long id) {
+        return new Task(id, "title", "content", "writer");
     }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -42,4 +42,10 @@ public class TaskController {
     public void delete(@PathVariable Long id) {
         logger.debug(id + " Successfully deleted");
     }
+
+    @PatchMapping("/tasks/{id}/{previousId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void move(@PathVariable Long id, @PathVariable Long previousId) {
+        logger.debug(id + " Successfully moved to " + previousId);
+    }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -29,4 +29,10 @@ public class TaskController {
     public void create(@RequestBody Task task) {
         logger.debug(task.toString());
     }
+
+    @PutMapping("/tasks/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void update(@PathVariable Long id, @RequestBody Task updatedTask) {
+        logger.debug(id + updatedTask.toString());
+    }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -12,35 +12,40 @@ public class TaskController {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
+    private TaskRepository taskRepository;
+
+    public TaskController(TaskRepository taskRepository) {
+        this.taskRepository = taskRepository;
+    }
+
     @GetMapping("/tasks")
     public List<Task> readAll() {
-        return Arrays.asList(new Task(1L, "title1", "content1", "writer1"),
-                new Task(2L, "title2", "content2", "writer2"),
-                new Task(3L, "title3", "content3", "writer3"));
+        return taskRepository.findAllByNotDeleted();
     }
 
     @GetMapping("/tasks/{id}")
     public Task readOne(@PathVariable Long id) {
-        return new Task(id, "title", "content", "writer");
+        return taskRepository.findOne(id);
     }
 
     @PostMapping("/tasks")
     @ResponseStatus(HttpStatus.CREATED)
     public Long create(@RequestBody Task task) {
-        logger.debug(task.toString());
-        return 1L;
+        return taskRepository.save(task).getId();
     }
 
     @PutMapping("/tasks/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void update(@PathVariable Long id, @RequestBody Task updatedTask) {
-        logger.debug(id + updatedTask.toString());
+        Task task = taskRepository.findOne(id).update(updatedTask);
+        taskRepository.save(task);
     }
 
     @DeleteMapping("/tasks/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        logger.debug(id + " Successfully deleted");
+        Task task = taskRepository.findOne(id).delete();
+        taskRepository.save(task);
     }
 
     @PatchMapping("/tasks/{id}/{previousId}")

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -26,8 +26,9 @@ public class TaskController {
 
     @PostMapping("/tasks")
     @ResponseStatus(HttpStatus.CREATED)
-    public void create(@RequestBody Task task) {
+    public Long create(@RequestBody Task task) {
         logger.debug(task.toString());
+        return 1L;
     }
 
     @PutMapping("/tasks/{id}")

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -64,7 +64,5 @@ public class TaskController {
         originalNextTask.moveAfter(taskToMove.getPreviousId());
         taskToMove.moveAfter(newNextTask.getPreviousId());
         newNextTask.moveAfter(taskToMove.getId());
-
-        logger.debug(id + " Successfully moved to " + targetId);
     }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -1,13 +1,16 @@
 package com.codesquad.esfj.todolist.task;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.*;
 
 @RestController
 public class TaskController {
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
     @GetMapping("/tasks")
     public List<Task> readAll() {
@@ -19,5 +22,11 @@ public class TaskController {
     @GetMapping("/tasks/{id}")
     public Task readOne(@PathVariable Long id) {
         return new Task(id, "title", "content", "writer");
+    }
+
+    @PostMapping("/tasks")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void create(@RequestBody Task task) {
+        logger.debug(task.toString());
     }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -1,0 +1,17 @@
+package com.codesquad.esfj.todolist.task;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.*;
+
+@RestController
+public class TaskController {
+
+    @GetMapping("/tasks")
+    public List<Task> readAll() {
+        return Arrays.asList(new Task("title1", "content1", "writer1"),
+                new Task("title2", "content2", "writer2"),
+                new Task("title3", "content3", "writer3"));
+    }
+}

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -35,4 +35,10 @@ public class TaskController {
     public void update(@PathVariable Long id, @RequestBody Task updatedTask) {
         logger.debug(id + updatedTask.toString());
     }
+
+    @DeleteMapping("/tasks/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void delete(@PathVariable Long id) {
+        logger.debug(id + " Successfully deleted");
+    }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
@@ -1,0 +1,35 @@
+package com.codesquad.esfj.todolist.task;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+@Component
+public class TaskRepository {
+    private Map<Long, Task> tasks = new ConcurrentHashMap<Long, Task>() {{
+        put(1L, new Task(1L, "title1", "content1", "writer1"));
+        put(2L, new Task(2L, "title2", "content2", "writer2"));
+    }};
+
+    public List<Task> findAllByNotDeleted() {
+        return tasks.values().stream()
+                .filter(task -> !task.isDeleted())
+                .collect(Collectors.toList());
+    }
+
+    public Task findOne(long id) {
+        return tasks.get(id);
+    }
+
+    public Task save(Task newTask) {
+        if (newTask.getId() == null) {
+            newTask.setId(tasks.size() + 1L);
+        }
+        tasks.put(newTask.getId(), newTask);
+        return newTask;
+    }
+}

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
@@ -2,7 +2,6 @@ package com.codesquad.esfj.todolist.task;
 
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -11,8 +10,11 @@ import java.util.stream.Collectors;
 @Component
 public class TaskRepository {
     private Map<Long, Task> tasks = new ConcurrentHashMap<Long, Task>() {{
-        put(1L, new Task(1L, "title1", "content1", "writer1"));
-        put(2L, new Task(2L, "title2", "content2", "writer2"));
+        Task task = new Task(1L, "title1", "content1", "writer1");
+        Task task2 = new Task(2L, "title2", "content2", "writer2");
+        task.moveAfter(2L);
+        put(1L, task);
+        put(2L, task2);
     }};
 
     public List<Task> findAllByNotDeleted() {
@@ -23,6 +25,13 @@ public class TaskRepository {
 
     public Task findOne(long id) {
         return tasks.get(id);
+    }
+
+    public Task findOneByPreviousId(long previousId) {
+        return tasks.values().stream()
+                .filter(task -> task.getPreviousId().equals(previousId))
+                .findAny()
+                .orElseThrow(IllegalStateException::new);
     }
 
     public Task save(Task newTask) {

--- a/backend/todo-list-backend/src/main/resources/application.properties
+++ b/backend/todo-list-backend/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+logging.level.com.codesquad.esfj.todolist.*: DEBUG


### PR DESCRIPTION
- Mockup API 구현.

- 현재 DB와 연결하지 않았기 때문에 Map 사용하여 저장 할 수 있도록 함.
   - Map으로 구현 시 아이디 값으로 조회하기 편리하여 사용

- soft delete 적용

- 실제 Repository와 유사하게 구현하기 위해서 수정과 삭제도 save 메소드 이용

- create는 201, 이외의 수정 작업은 204(NO_CONTENT) 사용
  - body가 요구사항에 없기 때문에 204 사용
- 이동 구현을 위해 LinkedList와 유사한 구조로 작성. 이전 Task의 Id를 참조하도록 함.
  - [참고](https://github.com/Dae-Hwa/todo-list/issues/9#issuecomment-814625644)



## 구현 항목

- `Task` 목록 조회
- 아이디로 `Task` 조회
- 이전 아이디로 `Task` 조회
- `Task` 생성
- `Task` 수정
- `Task` 삭제
- `Task` 이동

