### PR TITLE
[BE] delete시 previousId 참조 문제 해결

### DIFF
--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -50,8 +50,15 @@ public class TaskController {
     @DeleteMapping("/tasks/{id}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(@PathVariable Long id) {
-        Task task = taskRepository.findOne(id).delete();
-        taskRepository.save(task);
+        Task task = taskRepository.findOne(id);
+        Optional<Task> nextTask = taskRepository.findOneByPreviousId(id);
+        if (nextTask.isPresent()) {
+            Task presentNextTask = nextTask.get();
+            presentNextTask.moveAfter(task.getPreviousId());
+            taskRepository.save(presentNextTask);
+        }
+
+        taskRepository.save(task.delete());
     }
 
     @PatchMapping("/tasks/{id}/{targetId}")

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -31,7 +31,7 @@ public class TaskController {
     @PostMapping("/tasks")
     @ResponseStatus(HttpStatus.CREATED)
     public Long create(@RequestBody Task task) {
-        Task topTask = taskRepository.findOneByPreviousId(Task.TOP_PREVIOUS_ID).orElseThrow(IllegalArgumentException::new);
+        Task topTask = readByPreviousId(Task.TOP_PREVIOUS_ID);
         long id = taskRepository.save(task).getId();
 
         topTask.moveAfter(id);
@@ -65,11 +65,15 @@ public class TaskController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void move(@PathVariable Long id, @PathVariable Long targetId) {
         Task taskToMove = taskRepository.findOne(id);
-        Task originalNextTask = taskRepository.findOneByPreviousId(id).orElseThrow(IllegalArgumentException::new);
-        Task newNextTask = taskRepository.findOneByPreviousId(targetId).orElseThrow(IllegalArgumentException::new);
+        Task originalNextTask = readByPreviousId(id);
+        Task newNextTask = readByPreviousId(targetId);
 
         originalNextTask.moveAfter(taskToMove.getPreviousId());
         taskToMove.moveAfter(newNextTask.getPreviousId());
         newNextTask.moveAfter(taskToMove.getId());
+    }
+
+    private Task readByPreviousId(Long previousId) {
+        return taskRepository.findOneByPreviousId(previousId).orElseThrow(IllegalArgumentException::new);
     }
 }

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskController.java
@@ -31,7 +31,7 @@ public class TaskController {
     @PostMapping("/tasks")
     @ResponseStatus(HttpStatus.CREATED)
     public Long create(@RequestBody Task task) {
-        Task topTask = taskRepository.findOneByPreviousId(Task.TOP_PREVIOUS_ID);
+        Task topTask = taskRepository.findOneByPreviousId(Task.TOP_PREVIOUS_ID).orElseThrow(IllegalArgumentException::new);
         long id = taskRepository.save(task).getId();
 
         topTask.moveAfter(id);
@@ -58,8 +58,8 @@ public class TaskController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void move(@PathVariable Long id, @PathVariable Long targetId) {
         Task taskToMove = taskRepository.findOne(id);
-        Task originalNextTask = taskRepository.findOneByPreviousId(id);
-        Task newNextTask = taskRepository.findOneByPreviousId(targetId);
+        Task originalNextTask = taskRepository.findOneByPreviousId(id).orElseThrow(IllegalArgumentException::new);
+        Task newNextTask = taskRepository.findOneByPreviousId(targetId).orElseThrow(IllegalArgumentException::new);
 
         originalNextTask.moveAfter(taskToMove.getPreviousId());
         taskToMove.moveAfter(newNextTask.getPreviousId());

--- a/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
+++ b/backend/todo-list-backend/src/main/java/com/codesquad/esfj/todolist/task/TaskRepository.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
@@ -27,11 +28,10 @@ public class TaskRepository {
         return tasks.get(id);
     }
 
-    public Task findOneByPreviousId(long previousId) {
+    public Optional<Task> findOneByPreviousId(long previousId) {
         return tasks.values().stream()
                 .filter(task -> task.getPreviousId().equals(previousId))
-                .findAny()
-                .orElseThrow(IllegalStateException::new);
+                .findAny();
     }
 
     public Task save(Task newTask) {


### PR DESCRIPTION
delete 메서드 진행순서
1. 삭제할 태스크를 조회(task)
2. 1번의 태스크를 참조하는 태스크 조회(nextTask)
3. 1번이 참조하는 태스크를 2번이 참조하도록 한다

- previousId로 태스크가 조회되지 않는 경우(태스크가 맨 밑에 있거나 하나만 있는 경우)를 대비해 optional 사용